### PR TITLE
Add missing s so that WebStorm finds the declaration

### DIFF
--- a/examples/gc-mono-showcase.js
+++ b/examples/gc-mono-showcase.js
@@ -3,7 +3,7 @@ const logo = require("./logo.bmp.json");
 
 /**
  * Perform mono graphic showcase
- * @param {GraphicContext} gc
+ * @param {GraphicsContext} gc
  */
 function showcase(gc, interval) {
   // start

--- a/i2c.js
+++ b/i2c.js
@@ -89,7 +89,7 @@ class SSD1306 {
 
   /**
    * Return a graphic context
-   * @return {GraphicContext}
+   * @return {GraphicsContext}
    */
   getContext() {
     if (!this.context) {


### PR DESCRIPTION
WebStorm could not find what "gc" is supposed to be in the ex_i2c_128x64.js example. Turns out GraphicContext does not exist, but GraphicsContext does (see https://kalumajs.org/docs/api/graphics)